### PR TITLE
Provide mechanism to skip cloud provider tests [do not merge]

### DIFF
--- a/.github/workflows/test-provider.yaml
+++ b/.github/workflows/test-provider.yaml
@@ -59,9 +59,6 @@ jobs:
           - gitlab-ci
       fail-fast: false
     steps:
-      - name: "Debug Print NO_PROVIDER_CREDENTIALS"
-        run:  echo ${{ vars.NO_PROVIDER_CREDENTIALS }}
-
       - name: "Checkout Infrastructure"
         uses: actions/checkout@v4
 
@@ -70,7 +67,6 @@ jobs:
         run: hub pr checkout ${{ inputs.pr_number }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          #NO_PROVIDER_CREDENTIALS: ${{ vars.NO_PROVIDER_CREDENTIALS }}
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/test-provider.yaml
+++ b/.github/workflows/test-provider.yaml
@@ -32,8 +32,12 @@ on:
 
 jobs:
   test-render-providers:
-    # avoid running on PRs coming from a fork
-    if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request'
+    # Mechanism to prevent this test from running
+    # - on forks whose maintainers specify that provider credentials are absent (by setting a github variable NO_PROVIDER_CREDENTIALS)
+    # - on PRs coming from a fork (in which case github does not make the destination fork's credentials available)
+    if: |
+      vars.NO_PROVIDER_CREDENTIALS == '' &&
+      (github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request')
     name: "Test Nebari Provider"
     runs-on: ubuntu-latest
     permissions:
@@ -55,6 +59,9 @@ jobs:
           - gitlab-ci
       fail-fast: false
     steps:
+      - name: "Debug Print NO_PROVIDER_CREDENTIALS"
+        run:  echo ${{ vars.NO_PROVIDER_CREDENTIALS }}
+
       - name: "Checkout Infrastructure"
         uses: actions/checkout@v4
 
@@ -63,6 +70,7 @@ jobs:
         run: hub pr checkout ${{ inputs.pr_number }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          #NO_PROVIDER_CREDENTIALS: ${{ vars.NO_PROVIDER_CREDENTIALS }}
 
       - name: Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
Set NO_PROVIDER_CREDENTIALS github repo variable to skip the CI/CD provider tests.